### PR TITLE
feature/serviceprovider

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ composer require --dev regnerisch/laravel-beyond
 |`php artisan beyond:make:request Admin/Users/CreateUserRequest`|App/Admin/Users/Requests/CreateUserRequest||
 |`php artisan beyond:make:resource Admin/Users/UserResource`|App/Admin/Users/Resources/UserResource||
 |`php artisan beyond:make:route Users`|Creates a new file at routes/users.php||
+|`php artisan beyond:make:provider UserServiceProvider`|App/Providers/UserServiceProvider||
 |`php artisan beyond:setup`|Sets up a domain-driven application||
 
 #### Set up a domain-driven application

--- a/src/Commands/MakeCollectionCommand.php
+++ b/src/Commands/MakeCollectionCommand.php
@@ -3,7 +3,6 @@
 namespace Regnerisch\LaravelBeyond\Commands;
 
 use Illuminate\Console\Command;
-use Regnerisch\LaravelBeyond\Resolvers\AppNameSchemaResolver;
 use Regnerisch\LaravelBeyond\Resolvers\DomainNameSchemaResolver;
 
 class MakeCollectionCommand extends Command

--- a/src/Commands/MakeServiceProviderCommand.php
+++ b/src/Commands/MakeServiceProviderCommand.php
@@ -3,7 +3,6 @@
 namespace Regnerisch\LaravelBeyond\Commands;
 
 use Illuminate\Console\Command;
-use Regnerisch\LaravelBeyond\Resolvers\AppNameSchemaResolver;
 
 class MakeServiceProviderCommand extends Command
 {

--- a/src/Commands/MakeServiceProviderCommand.php
+++ b/src/Commands/MakeServiceProviderCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Regnerisch\LaravelBeyond\Commands;
+
+use Illuminate\Console\Command;
+use Regnerisch\LaravelBeyond\Resolvers\AppNameSchemaResolver;
+
+class MakeServiceProviderCommand extends Command
+{
+    protected $signature = 'beyond:make:service:provider {className}';
+
+    protected $description = 'Create a new service provider';
+
+    public function handle()
+    {
+        try {
+            $className = $this->argument('className');
+
+            beyond_copy_stub(
+                'service.provider.stub',
+                base_path() . "/src/App/Providers/{$className}.php",
+                [
+                    '{{ className }}' => $className,
+                ]
+            );
+
+            $this->info('Service provider created.');
+        } catch(\Exception $e) {
+            $this->error($e->getMessage());
+        }
+    }
+}

--- a/src/Commands/MakeServiceProviderCommand.php
+++ b/src/Commands/MakeServiceProviderCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Console\Command;
 
 class MakeServiceProviderCommand extends Command
 {
-    protected $signature = 'beyond:make:service:provider {className}';
+    protected $signature = 'beyond:make:provider {className}';
 
     protected $description = 'Create a new service provider';
 

--- a/src/Commands/MakeServiceProviderCommand.php
+++ b/src/Commands/MakeServiceProviderCommand.php
@@ -10,7 +10,7 @@ class MakeServiceProviderCommand extends Command
 
     protected $description = 'Create a new service provider';
 
-    public function handle()
+    public function handle(): void
     {
         try {
             $className = $this->argument('className');

--- a/src/LaravelBeyondServiceProvider.php
+++ b/src/LaravelBeyondServiceProvider.php
@@ -37,8 +37,8 @@ class LaravelBeyondServiceProvider extends ServiceProvider
                 MakeQueryCommand::class,
                 MakeRequestCommand::class,
                 MakeResourceCommand::class,
-                MakeServiceProviderCommand::class,
                 MakeRouteCommand::class,
+                MakeServiceProviderCommand::class,
                 SetupCommand::class,
             ]);
         }

--- a/src/LaravelBeyondServiceProvider.php
+++ b/src/LaravelBeyondServiceProvider.php
@@ -25,7 +25,6 @@ class LaravelBeyondServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
-                MakeServiceProviderCommand::class,
                 MakeActionCommand::class,
                 MakeCollectionCommand::class,
                 MakeCommandCommand::class,
@@ -38,6 +37,7 @@ class LaravelBeyondServiceProvider extends ServiceProvider
                 MakeQueryCommand::class,
                 MakeRequestCommand::class,
                 MakeResourceCommand::class,
+                MakeServiceProviderCommand::class,
                 MakeRouteCommand::class,
                 SetupCommand::class,
             ]);

--- a/src/LaravelBeyondServiceProvider.php
+++ b/src/LaravelBeyondServiceProvider.php
@@ -11,7 +11,6 @@ use Regnerisch\LaravelBeyond\Commands\MakeDataTransferObjectCommand;
 use Regnerisch\LaravelBeyond\Commands\MakeJobCommand;
 use Regnerisch\LaravelBeyond\Commands\MakeModelCommand;
 use Regnerisch\LaravelBeyond\Commands\MakePolicyCommand;
-use Regnerisch\LaravelBeyond\Commands\MakeProviderCommand;
 use Regnerisch\LaravelBeyond\Commands\MakeQueryBuilderCommand;
 use Regnerisch\LaravelBeyond\Commands\MakeQueryCommand;
 use Regnerisch\LaravelBeyond\Commands\MakeRequestCommand;

--- a/src/LaravelBeyondServiceProvider.php
+++ b/src/LaravelBeyondServiceProvider.php
@@ -11,11 +11,13 @@ use Regnerisch\LaravelBeyond\Commands\MakeDataTransferObjectCommand;
 use Regnerisch\LaravelBeyond\Commands\MakeJobCommand;
 use Regnerisch\LaravelBeyond\Commands\MakeModelCommand;
 use Regnerisch\LaravelBeyond\Commands\MakePolicyCommand;
+use Regnerisch\LaravelBeyond\Commands\MakeProviderCommand;
 use Regnerisch\LaravelBeyond\Commands\MakeQueryBuilderCommand;
 use Regnerisch\LaravelBeyond\Commands\MakeQueryCommand;
 use Regnerisch\LaravelBeyond\Commands\MakeRequestCommand;
 use Regnerisch\LaravelBeyond\Commands\MakeResourceCommand;
 use Regnerisch\LaravelBeyond\Commands\MakeRouteCommand;
+use Regnerisch\LaravelBeyond\Commands\MakeServiceProviderCommand;
 use Regnerisch\LaravelBeyond\Commands\SetupCommand;
 
 class LaravelBeyondServiceProvider extends ServiceProvider
@@ -24,6 +26,7 @@ class LaravelBeyondServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
+                MakeServiceProviderCommand::class,
                 MakeActionCommand::class,
                 MakeCollectionCommand::class,
                 MakeCommandCommand::class,

--- a/stubs/service.provider.stub
+++ b/stubs/service.provider.stub
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+
+class {{ className }} extends ServiceProvider
+{
+    public function register()
+    {
+        //
+    }
+
+    public function boot()
+    {
+        //
+    }
+}


### PR DESCRIPTION
Since I have a hunch that this will bother many I thought I'd add something. I hope that I have done a good job and thus service providers can also be created in `src/App/Providers` since `php artisan make:provider` does this in the normal App/ folder otherwise. Thanks.