### PR TITLE
use up instead of table in migration

### DIFF
--- a/stubs/migration.stub
+++ b/stubs/migration.stub
@@ -8,7 +8,7 @@ return new class extends Migration
 {
     public function up()
     {
-        Schema::table('{{ tableName }}', function (Blueprint $table) {
+        Schema::up('{{ tableName }}', function (Blueprint $table) {
             //
         });
     }


### PR DESCRIPTION
This PR bugfixes the stub of migrations to use `Schema::up` instead of `Schema::table`.