### PR TITLE
Remove old method fromRequest() from DTO stub

### DIFF
--- a/stubs/data-transfer-object.stub
+++ b/stubs/data-transfer-object.stub
@@ -2,13 +2,9 @@
 
 namespace Domain\{{ namespace }}\DataTransferObjects;
 
-use Illuminate\Http\Request;
 use Spatie\DataTransferObject\DataTransferObject;
 
 class {{ className }} extends DataTransferObject
 {
-    public static function fromRequest(Request $request): self
-    {
-        return new self($request->all());
-    }
+    // Add here properties
 }


### PR DESCRIPTION
From v3 of Spatie DTO package seem that fromRequest() it's not anymore the way to be used.

I checked readme of v2 and I found it, but in v3 it's not anymore there.