### PR TITLE
DTO Factory flag

### DIFF
--- a/src/Commands/MakeDataTransferObjectCommand.php
+++ b/src/Commands/MakeDataTransferObjectCommand.php
@@ -2,11 +2,13 @@
 
 namespace Regnerisch\LaravelBeyond\Commands;
 
+use Regnerisch\LaravelBeyond\Resolvers\AppNameSchemaResolver;
 use Regnerisch\LaravelBeyond\Resolvers\DomainNameSchemaResolver;
+use Illuminate\Support\Str;
 
 class MakeDataTransferObjectCommand extends BaseCommand
 {
-    protected $signature = 'beyond:make:dto {name?} {--overwrite}';
+    protected $signature = 'beyond:make:dto {name?} {--overwrite} {--factory}';
 
     protected $description = 'Make a new data transfer object';
 
@@ -19,6 +21,7 @@ class MakeDataTransferObjectCommand extends BaseCommand
         try {
             $name = $this->argument('name');
             $overwrite = $this->option('overwrite');
+            $factory = $this->option('factory');
 
             $schema = (new DomainNameSchemaResolver($this, $name))->handle();
 
@@ -31,6 +34,23 @@ class MakeDataTransferObjectCommand extends BaseCommand
                 ],
                 $overwrite
             );
+
+            if ($factory) {
+                $domainNamespace = $schema->namespace();
+                $className = $schema->className();
+                $schema = (new AppNameSchemaResolver($this, $className, $domainNamespace))->handle();
+                beyond_copy_stub(
+                    'data-transfer-object-factory.stub',
+                    Str::of(Str::beforeLast($schema->path('DataFactories'), '.php'))
+                        ->append('Factory.php'),
+                    [
+                        '{{ namespace }}' => $schema->namespace(),
+                        '{{ className }}' => $className,
+                        '{{ domainNamespace }}' => $domainNamespace
+                    ],
+                    $overwrite
+                );
+            }
 
             $this->components->info('DataTransferObject created.');
         } catch (\Exception $exception) {

--- a/stubs/data-transfer-object-factory.stub
+++ b/stubs/data-transfer-object-factory.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\{{ namespace }}\DataFactories;
+
+use Illuminate\Http\Request;
+
+use Domain\{{ domainNamespace }}\DataTransferObjects\{{ className }};
+
+class {{ className }}Factory
+{
+    public static function fromRequest(Request $request): {{ className }}
+    {
+        return new {{ className }}($request->all());
+    }
+}

--- a/stubs/data-transfer-object.stub
+++ b/stubs/data-transfer-object.stub
@@ -2,13 +2,9 @@
 
 namespace Domain\{{ namespace }}\DataTransferObjects;
 
-use Illuminate\Http\Request;
 use Spatie\DataTransferObject\DataTransferObject;
 
 class {{ className }} extends DataTransferObject
 {
-    public static function fromRequest(Request $request): self
-    {
-        return new self($request->all());
-    }
+    // Add properties here
 }

--- a/tests/Commands/MakeDataTransferObjectCommandTest.php
+++ b/tests/Commands/MakeDataTransferObjectCommandTest.php
@@ -16,3 +16,17 @@ test('can make dto', function () {
         ->toMatchNamespaceAndClassName()
         ->toPlaceholdersBeReplaced();
 });
+
+test('can make dto with factory', function () {
+    $composer = $this->app->make(ComposerContract::class);
+
+    $composer->setPackages(['spatie/data-transfer-object']);
+
+    $this->artisan('beyond:make:dto User/UserData --factory')
+        ->expectsQuestion('Please enter the app name', 'Web');
+
+    expect(base_path() . '/src/App/Web/User/DataFactories/UserDataFactory.php')
+        ->toBeFile()
+        ->toMatchNamespaceAndClassName()
+        ->toPlaceholdersBeReplaced();
+});


### PR DESCRIPTION
As discussed here https://github.com/regnerisch/laravel-beyond/pull/58 this PR add a new optional flag `--factory` in DTO command. When added will be create a new class in App for DTO Factory.

Usage:

```bash
# Will ask Domain, Class name and App
beyond:make:dto --factory

# Will ask App and create the factory in 
# `src/App/Web/User/DataFactories/UserDataFactory.php` (Supposely App provided is "Web")
beyond:make:dto User/UserData --factory
```

A DTO like this:

```php
<?php

namespace Domain\Users\DataTransferObjects;

use Spatie\DataTransferObject\DataTransferObject;

class MyData extends DataTransferObject
{
    // Add properties here
}
```

Will create a DTO Factory:

```php
<?php

namespace App\Admin\Users\DataFactories;

use Illuminate\Http\Request;

use Domain\Users\DataTransferObjects\MyData;

class MyDataFactory
{
    public static function fromRequest(Request $request): MyData
    {
        return new MyData($request->all());
    }
}
```