### PR TITLE
Added FQN to command output

### DIFF
--- a/src/Commands/SetupCommand.php
+++ b/src/Commands/SetupCommand.php
@@ -104,7 +104,7 @@ class SetupCommand extends BaseCommand
             $this->components->info(
                 'Do not forget to add following code into the boot() function of your AppServiceProvider:' . PHP_EOL . PHP_EOL .
 
-                'Factory::guessFactoryNamesUsing(function (string $modelName) {' . PHP_EOL .
+                'Illuminate\Database\Eloquent\Factories\Factory::guessFactoryNamesUsing(function (string $modelName) {' . PHP_EOL .
                 "\t" . 'return \'Database\\Factories\\\' . class_basename($modelName) . \'Factory\';' . PHP_EOL .
                 '});' . PHP_EOL
             );

--- a/src/Commands/SetupCommand.php
+++ b/src/Commands/SetupCommand.php
@@ -103,9 +103,9 @@ class SetupCommand extends BaseCommand
             $this->components->info('Setup completed.');
             $this->components->info(
                 'Do not forget to add following code into the boot() function of your AppServiceProvider:' . PHP_EOL . PHP_EOL .
-
+                
                 'Illuminate\Database\Eloquent\Factories\Factory::guessFactoryNamesUsing(function (string $modelName) {' . PHP_EOL .
-                "\t" . 'return \'Database\\Factories\\\' . class_basename($modelName) . \'Factory\';' . PHP_EOL .
+                "\t" . 'return \'Database\\\Factories\\\' . class_basename($modelName) . \'Factory\';' . PHP_EOL .
                 '});' . PHP_EOL
             );
         } catch (\Exception $exception) {


### PR DESCRIPTION
Fixes #68 and adds the FQDN to the command output so it is clearer.

I abandoned plans to add it automatically with PHP Parser so the user stays in control.