### PR TITLE
Allow user to create model using shortcuts

### DIFF
--- a/src/Commands/MakeModelCommand.php
+++ b/src/Commands/MakeModelCommand.php
@@ -7,7 +7,7 @@ use Regnerisch\LaravelBeyond\Resolvers\DomainNameSchemaResolver;
 
 class MakeModelCommand extends BaseCommand
 {
-    protected $signature = 'beyond:make:model {name?} {-f|--factory} {-m|--migration} {--force}';
+    protected $signature = 'beyond:make:model {name?} {--f|factory} {--m|migration} {--force}';
 
     protected $description = 'Make a new model';
 

--- a/tests/Commands/MakeModelCommandTest.php
+++ b/tests/Commands/MakeModelCommandTest.php
@@ -31,3 +31,23 @@ test('can make model, factory and migration are created', function () {
         ->toBeFile()
         ->toPlaceholdersBeReplaced();
 });
+
+
+test('can make model, factory and migration are created using shortcuts', function () {
+    $this->artisan('beyond:make:model User/User -mf --force');
+
+    expect(base_path() . '/src/Domain/User/Models/User.php')
+        ->toBeFile()
+        ->toMatchNamespaceAndClassName()
+        ->toPlaceholdersBeReplaced();
+
+    $date = Carbon::parse()->format('Y_m_d_his');
+
+    expect(base_path() . "/database/migrations/{$date}_create_users_table.php")
+        ->toBeFile()
+        ->toPlaceholdersBeReplaced();
+
+    expect(base_path() . '/database/factories/UserFactory.php')
+        ->toBeFile()
+        ->toPlaceholdersBeReplaced();
+});


### PR DESCRIPTION
Hi,
Currently, there is an error while creating a model using shortcuts so this PR will fix that issue.
Error Message: The "-m" option does not exist.
Thanks